### PR TITLE
Accept single-date valid range (minDate == maxDate)

### DIFF
--- a/library/src/main/java/com/afollestad/date/controllers/MinMaxController.kt
+++ b/library/src/main/java/com/afollestad/date/controllers/MinMaxController.kt
@@ -118,8 +118,8 @@ internal class MinMaxController {
 
   private fun validateMinAndMax() {
     if (minDate != null && maxDate != null) {
-      check(minDate!! < maxDate!!) {
-        "Min date must be less than max date."
+      check(minDate!! <= maxDate!!) {
+        "Min date must be at most max date."
       }
     }
   }

--- a/library/src/test/java/com/afollestad/date/controllers/MinMaxControllerTest.kt
+++ b/library/src/test/java/com/afollestad/date/controllers/MinMaxControllerTest.kt
@@ -39,11 +39,18 @@ class MinMaxControllerTest {
     assertThat(controller.getMinDate()!!.snapshot()).isEqualTo(snapshot)
   }
 
-  @Test fun `setMinDate - with date that is greater than or equal to max date`() {
+  @Test fun `setMinDate - with date that is greater than max date`() {
     controller.setMaxDate(1995, Calendar.JULY, 28)
     assertException(IllegalStateException::class) {
       controller.setMinDate(1995, Calendar.JULY, 29)
     }
+  }
+
+  @Test fun `setMinDate - with date that is equal to max date`() {
+    val snapshot = DateSnapshot(Calendar.JULY, 28, 1995)
+    controller.setMaxDate(snapshot.year, snapshot.month, snapshot.day)
+    controller.setMinDate(snapshot.year, snapshot.month, snapshot.day)
+    assertThat(controller.getMinDate()!!.snapshot()).isEqualTo(snapshot)
   }
 
   @Test fun setMaxDate() {


### PR DESCRIPTION
Allow valid ranges that are only a single day long. This allows using the date-picker widget in a context where the valid range for date selection varies, but also selecting "no date" is an option, without handling the case where the valid range is just a single day long differently.
