### PR TITLE
Fix invalid range tube drawable for first/last day of month

### DIFF
--- a/library/src/main/java/com/afollestad/date/controllers/MinMaxController.kt
+++ b/library/src/main/java/com/afollestad/date/controllers/MinMaxController.kt
@@ -87,12 +87,15 @@ internal class MinMaxController {
   fun getOutOfMinRangeBackgroundRes(date: DateSnapshot): Int {
     val calendar = date.asCalendar()
     val isLastInMonth = calendar.dayOfMonth == calendar.totalDaysInMonth
+
+    val isFirstInMonth = date.day == 1
+    val isLastDayOutOfRange = date == minDate!!.addDays(-1)
+
     return when {
+      isLastDayOutOfRange && isFirstInMonth -> R.drawable.ic_tube_start_end
+      isFirstInMonth -> R.drawable.ic_tube_start
       isLastInMonth -> R.drawable.ic_tube_end
-      date.day == 1 -> R.drawable.ic_tube_start
-      date.day == minDate!!.day - 1 &&
-          date.month == minDate!!.month &&
-          date.year == minDate!!.year -> R.drawable.ic_tube_end
+      isLastDayOutOfRange -> R.drawable.ic_tube_end
       else -> R.drawable.ic_tube_middle
     }
   }
@@ -106,12 +109,15 @@ internal class MinMaxController {
   fun getOutOfMaxRangeBackgroundRes(date: DateSnapshot): Int {
     val calendar = date.asCalendar()
     val isLastInMonth = calendar.dayOfMonth == calendar.totalDaysInMonth
+
+    val isFirstInMonth = date.day == 1
+    val isFirstDayOutOfRange = date == maxDate!!.addDays(1)
+
     return when {
-      date.day == 1 -> R.drawable.ic_tube_start
-      date.day == maxDate!!.day + 1 &&
-          date.month == maxDate!!.month &&
-          date.year == maxDate!!.year -> R.drawable.ic_tube_start
+      isFirstInMonth -> R.drawable.ic_tube_start
+      isFirstDayOutOfRange && isLastInMonth -> R.drawable.ic_tube_start_end
       isLastInMonth -> R.drawable.ic_tube_end
+      isFirstDayOutOfRange -> R.drawable.ic_tube_start
       else -> R.drawable.ic_tube_middle
     }
   }

--- a/library/src/main/java/com/afollestad/date/data/snapshot/DateSnapshot.kt
+++ b/library/src/main/java/com/afollestad/date/data/snapshot/DateSnapshot.kt
@@ -47,6 +47,8 @@ internal data class DateSnapshot(
     if (year == other.year && month == other.month && day < other.day) return -1
     return 1
   }
+
+  fun addDays(days: Int) = asCalendar().apply { add(Calendar.DAY_OF_MONTH, days) }.snapshot()
 }
 
 /** @author Aidan Follestad (@afollestad) */

--- a/library/src/main/res/drawable/ic_tube_start_end.xml
+++ b/library/src/main/res/drawable/ic_tube_start_end.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+  <corners
+      android:bottomLeftRadius="@dimen/week_day_row_height"
+      android:topLeftRadius="@dimen/week_day_row_height"
+      android:bottomRightRadius="@dimen/week_day_row_height"
+      android:topRightRadius="@dimen/week_day_row_height" />
+  <solid android:color="#000000" />
+</shape>


### PR DESCRIPTION
If the invalid range ends on the first of a month, or starts on the last of a month,
the background is now rounded on both ends instead of just one.